### PR TITLE
feat: implement farcaster link campaign dapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,45 @@
-# sv
+# Farcaster Link Rewards dapp
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+This repository contains two main parts:
 
-## Creating a project
+- **Solidity contracts** in `contracts/` for link tokenisation, per-click ad campaigns and USDC reward distribution on Base.
+- **SvelteKit frontend** with dedicated flows to buy link tokens, fund or manage campaigns and claim accrued rewards.
 
-If you're seeing this, you've probably already done this step. Congrats!
+## Smart contracts overview
 
-```sh
-# create a new project in the current directory
-npx sv create
+| Contract             | Responsibility                                                                                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LinkTokenFactory`   | Canonicalises links, deterministically deploys ERC-20 link tokens, exposes a fixed-price purchase helper and keeps a registry of all issued tokens. |
+| `RewardsDistributor` | Accepts USDC from campaigns, tracks per-token accumulated rewards and exposes claim functions and 24h revenue metrics.                              |
+| `AdCampaigns`        | Manages CPC budgets, enforces attested clicks, moves USDC into the distributor and lets advertisers pause or close campaigns.                       |
 
-# create a new project in my-app
-npx sv create my-app
+All contracts are written for Solidity `^0.8.24` and avoid external dependencies so they can be compiled with the toolchain of your choice.
+
+## Frontend configuration
+
+The Svelte app reads contract addresses from environment variables. Set the following before running `npm run dev`:
+
+```bash
+VITE_FACTORY_ADDRESS=0x...             # deployed LinkTokenFactory
+VITE_DISTRIBUTOR_ADDRESS=0x...         # associated RewardsDistributor
+VITE_AD_CAMPAIGNS_ADDRESS=0x...        # deployed AdCampaigns manager
 ```
 
-## Developing
+The frontend talks directly to `window.ethereum`, so a browser wallet such as MetaMask on Base is required.
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+## Available pages
 
-```sh
+- `/buy` – canonicalise any Farcaster URL, deploy or locate its link token, inspect metrics and purchase tokens (after granting a USDC allowance).
+- `/advertise` – create new CPC campaigns, top up budgets and control campaign status.
+- `/claim` – inspect every link token you hold (using the factory registry) and pull claimable USDC individually or in batch.
+
+## Local development
+
+Install dependencies and run the dev server:
+
+```bash
+npm install
 npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
 ```
 
-## Building
-
-To create a production version of your app:
-
-```sh
-npm run build
-```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+Set the environment variables above and connect a wallet on Base to exercise on-chain flows.

--- a/contracts/AdCampaigns.sol
+++ b/contracts/AdCampaigns.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC20, SafeTransferLib} from "./libraries/SafeTransferLib.sol";
+import {Errors} from "./utils/Errors.sol";
+import {LinkTokenFactory} from "./LinkTokenFactory.sol";
+import {ILinkToken} from "./interfaces/ILinkToken.sol";
+import {IRewardsDistributor} from "./interfaces/IRewardsDistributor.sol";
+import {ECDSA} from "./libraries/ECDSA.sol";
+
+contract AdCampaigns {
+    using SafeTransferLib for IERC20;
+
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant CLICK_TYPEHASH = keccak256("Click(uint256 campaignId,bytes32 adId,bytes32 linkId,bytes32 clickId,uint256 cpc,uint256 timestamp,address clicker)");
+    string private constant NAME = "FarcasterClick";
+    string private constant VERSION = "1";
+
+    IERC20 public immutable usdc;
+    LinkTokenFactory public immutable factory;
+    IRewardsDistributor public immutable distributor;
+
+    uint256 public immutable minCpc;
+    uint256 public immutable maxCpc;
+    uint256 public immutable maxClockSkew;
+
+    struct Campaign {
+        address advertiser;
+        bytes32 adId;
+        bytes32 linkId;
+        address linkToken;
+        uint128 cpc;
+        uint128 totalDeposited;
+        uint128 spent;
+        uint64 totalClicks;
+        bool paused;
+        bool closed;
+    }
+
+    uint256 public nextCampaignId = 1;
+
+    mapping(uint256 => Campaign) public campaigns;
+    mapping(address => bool) public attesters;
+    mapping(bytes32 => bool) public consumedClicks;
+
+    event CampaignCreated(uint256 indexed campaignId, address indexed advertiser, bytes32 indexed linkId, bytes32 adId, uint256 cpc, uint256 deposit);
+    event CampaignFunded(uint256 indexed campaignId, uint256 amount, uint256 newBudget);
+    event CampaignStatusChanged(uint256 indexed campaignId, bool paused);
+    event CampaignClosed(uint256 indexed campaignId, uint256 refundAmount);
+    event ClickRecorded(uint256 indexed campaignId, bytes32 indexed clickId, uint256 cpc, address indexed clicker);
+    event AttesterUpdated(address indexed attester, bool allowed);
+
+    modifier onlyAdvertiser(uint256 campaignId) {
+        require(campaigns[campaignId].advertiser == msg.sender, Errors.UNAUTHORIZED);
+        _;
+    }
+
+    constructor(
+        address usdc_,
+        address factory_,
+        uint256 minCpc_,
+        uint256 maxCpc_,
+        uint256 maxClockSkew_,
+        address[] memory initialAttesters
+    ) {
+        require(usdc_ != address(0) && factory_ != address(0), Errors.ZERO_ADDRESS);
+        require(minCpc_ > 0 && maxCpc_ >= minCpc_, Errors.CPC_OUT_OF_BOUNDS);
+        usdc = IERC20(usdc_);
+        factory = LinkTokenFactory(factory_);
+        distributor = IRewardsDistributor(factory.distributorAddress());
+        distributor.setCampaigns(address(this));
+        minCpc = minCpc_;
+        maxCpc = maxCpc_;
+        maxClockSkew = maxClockSkew_;
+        for (uint256 i = 0; i < initialAttesters.length; i++) {
+            attesters[initialAttesters[i]] = true;
+            emit AttesterUpdated(initialAttesters[i], true);
+        }
+    }
+
+    function createCampaign(
+        bytes32 adId,
+        bytes32 linkId,
+        address linkToken,
+        uint256 cpc,
+        uint256 depositAmount
+    ) external returns (uint256 campaignId) {
+        require(cpc >= minCpc && cpc <= maxCpc, Errors.CPC_OUT_OF_BOUNDS);
+        require(linkToken != address(0) && linkId == ILinkToken(linkToken).linkId(), Errors.INVALID_INPUT);
+        require(depositAmount >= cpc && depositAmount <= type(uint128).max, Errors.INVALID_INPUT);
+
+        campaignId = nextCampaignId++;
+        campaigns[campaignId] = Campaign({
+            advertiser: msg.sender,
+            adId: adId,
+            linkId: linkId,
+            linkToken: linkToken,
+            cpc: uint128(cpc),
+            totalDeposited: uint128(depositAmount),
+            spent: 0,
+            totalClicks: 0,
+            paused: false,
+            closed: false
+        });
+
+        usdc.safeTransferFrom(msg.sender, address(this), depositAmount);
+
+        emit CampaignCreated(campaignId, msg.sender, linkId, adId, cpc, depositAmount);
+    }
+
+    function fundCampaign(uint256 campaignId, uint256 amount) external onlyAdvertiser(campaignId) {
+        Campaign storage campaign = campaigns[campaignId];
+        require(!campaign.closed, Errors.CAMPAIGN_CLOSED);
+        require(amount > 0 && amount <= type(uint128).max, Errors.INVALID_INPUT);
+        uint256 newTotal = uint256(campaign.totalDeposited) + amount;
+        require(newTotal <= type(uint128).max, Errors.OVERFLOW);
+        campaign.totalDeposited = uint128(newTotal);
+        usdc.safeTransferFrom(msg.sender, address(this), amount);
+        emit CampaignFunded(campaignId, amount, remainingBudget(campaignId));
+    }
+
+    function pauseCampaign(uint256 campaignId, bool pause) external onlyAdvertiser(campaignId) {
+        Campaign storage campaign = campaigns[campaignId];
+        require(!campaign.closed, Errors.CAMPAIGN_CLOSED);
+        campaign.paused = pause;
+        emit CampaignStatusChanged(campaignId, pause);
+    }
+
+    function closeCampaign(uint256 campaignId, address refundTo) external onlyAdvertiser(campaignId) {
+        Campaign storage campaign = campaigns[campaignId];
+        require(!campaign.closed, Errors.CAMPAIGN_CLOSED);
+        campaign.closed = true;
+        campaign.paused = true;
+        uint256 remaining = remainingBudget(campaignId);
+        campaign.totalDeposited = campaign.spent;
+        if (remaining > 0) {
+            usdc.safeTransfer(refundTo, remaining);
+        }
+        emit CampaignClosed(campaignId, remaining);
+    }
+
+    function recordClick(
+        uint256 campaignId,
+        bytes32 clickId,
+        uint256 cpc,
+        uint256 timestamp,
+        address clicker,
+        bytes calldata signature
+    ) external {
+        Campaign storage campaign = campaigns[campaignId];
+        require(!campaign.closed, Errors.CAMPAIGN_CLOSED);
+        require(!campaign.paused, Errors.CAMPAIGN_NOT_ACTIVE);
+        require(cpc == campaign.cpc, Errors.INVALID_INPUT);
+        require(timestamp + maxClockSkew >= block.timestamp && timestamp <= block.timestamp + maxClockSkew, Errors.TIMESTAMP_OUT_OF_RANGE);
+        require(!consumedClicks[clickId], Errors.CLICK_ALREADY_CONSUMED);
+
+        bytes32 digest = _hashClick(campaignId, campaign.adId, campaign.linkId, clickId, cpc, timestamp, clicker);
+        address signer = ECDSA.recover(digest, signature);
+        require(attesters[signer], Errors.UNAUTHORIZED);
+
+        uint256 remaining = remainingBudget(campaignId);
+        require(remaining >= cpc, Errors.INSUFFICIENT_REMAINING_BUDGET);
+
+        consumedClicks[clickId] = true;
+        uint256 newSpent = uint256(campaign.spent) + cpc;
+        require(newSpent <= type(uint128).max, Errors.OVERFLOW);
+        campaign.spent = uint128(newSpent);
+        campaign.totalClicks += 1;
+
+        usdc.safeTransfer(address(distributor), cpc);
+        distributor.notifyReward(campaign.linkToken, cpc);
+
+        emit ClickRecorded(campaignId, clickId, cpc, clicker);
+    }
+
+    function remainingBudget(uint256 campaignId) public view returns (uint256) {
+        Campaign storage campaign = campaigns[campaignId];
+        return uint256(campaign.totalDeposited) - uint256(campaign.spent);
+    }
+
+    function setAttester(address attester, bool allowed) external {
+        require(msg.sender == address(factory), Errors.UNAUTHORIZED);
+        attesters[attester] = allowed;
+        emit AttesterUpdated(attester, allowed);
+    }
+
+    function _domainSeparatorV4() private view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes(NAME)),
+                keccak256(bytes(VERSION)),
+                block.chainid,
+                address(this)
+            )
+        );
+    }
+
+    function _hashClick(
+        uint256 campaignId,
+        bytes32 adId,
+        bytes32 linkId,
+        bytes32 clickId,
+        uint256 cpc,
+        uint256 timestamp,
+        address clicker
+    ) private view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(CLICK_TYPEHASH, campaignId, adId, linkId, clickId, cpc, timestamp, clicker));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparatorV4(), structHash));
+    }
+}

--- a/contracts/LinkToken.sol
+++ b/contracts/LinkToken.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ERC20} from "./utils/ERC20.sol";
+import {IRewardsDistributor} from "./interfaces/IRewardsDistributor.sol";
+import {Errors} from "./utils/Errors.sol";
+
+contract LinkToken is ERC20 {
+    address public immutable factory;
+    bytes32 public immutable linkId;
+    IRewardsDistributor public immutable distributor;
+
+    modifier onlyFactory() {
+        require(msg.sender == factory, Errors.UNAUTHORIZED);
+        _;
+    }
+
+    constructor(
+        address factory_,
+        bytes32 linkId_,
+        address distributor_,
+        string memory name_,
+        string memory symbol_
+    ) ERC20(name_, symbol_, 18) {
+        require(factory_ != address(0) && distributor_ != address(0), Errors.ZERO_ADDRESS);
+        factory = factory_;
+        linkId = linkId_;
+        distributor = IRewardsDistributor(distributor_);
+    }
+
+    function mint(address to, uint256 amount) external onlyFactory {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external onlyFactory {
+        _burn(from, amount);
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 value) internal override {
+        if (from != address(0)) {
+            distributor.updateUser(address(this), from);
+        }
+        if (to != address(0)) {
+            distributor.updateUser(address(this), to);
+        }
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256) internal override {
+        if (from != address(0)) {
+            distributor.afterTokenTransfer(address(this), from);
+        }
+        if (to != address(0)) {
+            distributor.afterTokenTransfer(address(this), to);
+        }
+    }
+}

--- a/contracts/LinkTokenFactory.sol
+++ b/contracts/LinkTokenFactory.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {LinkToken} from "./LinkToken.sol";
+import {RewardsDistributor} from "./RewardsDistributor.sol";
+import {IERC20, SafeTransferLib} from "./libraries/SafeTransferLib.sol";
+import {LinkCanonicalizer} from "./libraries/LinkCanonicalizer.sol";
+import {Errors} from "./utils/Errors.sol";
+
+contract LinkTokenFactory {
+    using SafeTransferLib for IERC20;
+
+    IERC20 public immutable usdc;
+    RewardsDistributor public immutable distributor;
+    address public immutable treasury;
+
+    uint256 public immutable tokenPrice; // price per token in USDC (6 decimals)
+    address public immutable owner;
+
+    mapping(bytes32 => address) public linkTokenForId;
+    address[] public allLinkTokens;
+
+    event LinkTokenCreated(bytes32 indexed linkId, address linkToken, string canonicalLink);
+    event TokensPurchased(bytes32 indexed linkId, address indexed buyer, uint256 amount, uint256 cost);
+
+    constructor(address usdc_, address treasury_, uint256 tokenPrice_) {
+        require(usdc_ != address(0) && treasury_ != address(0), Errors.ZERO_ADDRESS);
+        require(tokenPrice_ > 0, Errors.INVALID_INPUT);
+        usdc = IERC20(usdc_);
+        treasury = treasury_;
+        tokenPrice = tokenPrice_;
+        distributor = new RewardsDistributor(usdc_, address(this));
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, Errors.UNAUTHORIZED);
+        _;
+    }
+
+    function getOrCreateLinkToken(bytes32 linkId, string calldata canonicalLink, string calldata symbol) external returns (address) {
+        address existing = linkTokenForId[linkId];
+        if (existing != address(0)) {
+            return existing;
+        }
+        string memory name = string(abi.encodePacked("Link: ", canonicalLink));
+        LinkToken token = new LinkToken(address(this), linkId, address(distributor), name, symbol);
+        address tokenAddress = address(token);
+        linkTokenForId[linkId] = tokenAddress;
+        allLinkTokens.push(tokenAddress);
+        emit LinkTokenCreated(linkId, tokenAddress, canonicalLink);
+        return tokenAddress;
+    }
+
+    function purchase(bytes32 linkId, uint256 amount, address recipient) external {
+        require(amount > 0, Errors.INVALID_INPUT);
+        address tokenAddress = linkTokenForId[linkId];
+        require(tokenAddress != address(0), Errors.INVALID_INPUT);
+        uint256 cost = amount * tokenPrice;
+        usdc.safeTransferFrom(msg.sender, treasury, cost);
+        LinkToken(tokenAddress).mint(recipient, amount);
+        emit TokensPurchased(linkId, msg.sender, amount, cost);
+    }
+
+    function getAllLinkTokens() external view returns (address[] memory) {
+        return allLinkTokens;
+    }
+
+    function getLinkToken(bytes32 linkId) external view returns (address) {
+        return linkTokenForId[linkId];
+    }
+
+    function configureCampaigns(address campaigns_) external onlyOwner {
+        distributor.setCampaigns(campaigns_);
+    }
+
+    function canonicalize(string calldata rawLink) external pure returns (string memory) {
+        return LinkCanonicalizer.canonicalize(rawLink);
+    }
+
+    function computeLinkId(string calldata rawLink) external pure returns (bytes32) {
+        return LinkCanonicalizer.computeLinkId(rawLink);
+    }
+
+    function distributorAddress() external view returns (address) {
+        return address(distributor);
+    }
+}

--- a/contracts/RewardsDistributor.sol
+++ b/contracts/RewardsDistributor.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC20, SafeTransferLib} from "./libraries/SafeTransferLib.sol";
+import {ILinkToken} from "./interfaces/ILinkToken.sol";
+import {Errors} from "./utils/Errors.sol";
+
+contract RewardsDistributor {
+    using SafeTransferLib for IERC20;
+
+    uint256 private constant ACC_PRECISION = 1e18;
+    uint256 private constant HOURS_IN_DAY = 24;
+
+    IERC20 public immutable usdc;
+    address public immutable factory;
+    address public campaigns;
+
+    struct RewardData {
+        uint256 accPerShare;
+        uint256 queuedRewards;
+    }
+
+    mapping(address => RewardData) public rewardData;
+    mapping(address => mapping(address => uint256)) public rewardDebt;
+    mapping(address => mapping(address => uint256)) public pending;
+
+    mapping(address => mapping(uint64 => uint256)) internal hourlyRevenue;
+    mapping(address => uint64) public lastRecordedHour;
+
+    event RewardAdded(address indexed linkToken, uint256 amount, uint256 accPerShare);
+    event Claimed(address indexed linkToken, address indexed user, address indexed to, uint256 amount);
+    event CampaignsUpdated(address indexed newCampaigns);
+
+    modifier onlyFactory() {
+        require(msg.sender == factory, Errors.UNAUTHORIZED);
+        _;
+    }
+
+    constructor(address usdc_, address factory_) {
+        require(usdc_ != address(0) && factory_ != address(0), Errors.ZERO_ADDRESS);
+        usdc = IERC20(usdc_);
+        factory = factory_;
+    }
+
+    function notifyReward(address linkToken, uint256 amount) external {
+        require(msg.sender == factory || msg.sender == campaigns, Errors.UNAUTHORIZED);
+        RewardData storage data = rewardData[linkToken];
+        uint256 totalSupply = ILinkToken(linkToken).totalSupply();
+        _bumpHour(linkToken, amount);
+        if (totalSupply == 0) {
+            data.queuedRewards += amount;
+            return;
+        }
+        uint256 totalAmount = amount + data.queuedRewards;
+        data.queuedRewards = 0;
+        data.accPerShare += (totalAmount * ACC_PRECISION) / totalSupply;
+        emit RewardAdded(linkToken, totalAmount, data.accPerShare);
+    }
+
+    function setCampaigns(address campaigns_) external onlyFactory {
+        require(campaigns_ != address(0), Errors.ZERO_ADDRESS);
+        campaigns = campaigns_;
+        emit CampaignsUpdated(campaigns_);
+    }
+
+    function updateUser(address linkToken, address user) external {
+        require(msg.sender == linkToken, Errors.UNAUTHORIZED);
+        _updateUser(linkToken, user);
+    }
+
+    function afterTokenTransfer(address linkToken, address user) external {
+        require(msg.sender == linkToken, Errors.UNAUTHORIZED);
+        _syncUserDebt(linkToken, user);
+    }
+
+    function claim(address linkToken, address to) external returns (uint256) {
+        _updateUser(linkToken, msg.sender);
+        return _payout(linkToken, msg.sender, to);
+    }
+
+    function claimBatch(address[] calldata linkTokens, address to) external returns (uint256 totalClaimed) {
+        for (uint256 i = 0; i < linkTokens.length; i++) {
+            address token = linkTokens[i];
+            _updateUser(token, msg.sender);
+            totalClaimed += _payout(token, msg.sender, to);
+        }
+    }
+
+    function pendingRewards(address linkToken, address user) external view returns (uint256) {
+        RewardData storage data = rewardData[linkToken];
+        uint256 acc = data.accPerShare;
+        uint256 totalSupply = ILinkToken(linkToken).totalSupply();
+        if (totalSupply > 0) {
+            uint256 totalAmount = data.queuedRewards;
+            if (totalAmount > 0) {
+                acc += (totalAmount * ACC_PRECISION) / totalSupply;
+            }
+        }
+        uint256 balance = ILinkToken(linkToken).balanceOf(user);
+        uint256 accumulated = (balance * acc) / ACC_PRECISION;
+        uint256 debt = rewardDebt[linkToken][user];
+        uint256 stored = pending[linkToken][user];
+        if (accumulated <= debt) {
+            return stored;
+        }
+        return stored + (accumulated - debt);
+    }
+
+    function revenueLast24Hours(address linkToken) external view returns (uint256 total) {
+        uint64 currentHour = uint64(block.timestamp / 1 hours);
+        for (uint256 i = 0; i < HOURS_IN_DAY; i++) {
+            if (currentHour < i) {
+                break;
+            }
+            uint64 hourId = currentHour - uint64(i);
+            total += hourlyRevenue[linkToken][hourId];
+        }
+    }
+
+    function _payout(address linkToken, address user, address to) private returns (uint256) {
+        uint256 amount = pending[linkToken][user];
+        if (amount == 0) {
+            _syncUserDebt(linkToken, user);
+            return 0;
+        }
+        pending[linkToken][user] = 0;
+        _syncUserDebt(linkToken, user);
+        usdc.safeTransfer(to, amount);
+        emit Claimed(linkToken, user, to, amount);
+        return amount;
+    }
+
+    function _updateUser(address linkToken, address user) private {
+        if (user == address(0)) {
+            return;
+        }
+        RewardData storage data = rewardData[linkToken];
+        uint256 acc = data.accPerShare;
+        uint256 totalSupply = ILinkToken(linkToken).totalSupply();
+        if (totalSupply > 0 && data.queuedRewards > 0) {
+            acc += (data.queuedRewards * ACC_PRECISION) / totalSupply;
+        }
+        uint256 balance = ILinkToken(linkToken).balanceOf(user);
+        uint256 accumulated = (balance * acc) / ACC_PRECISION;
+        uint256 debt = rewardDebt[linkToken][user];
+        if (accumulated > debt) {
+            pending[linkToken][user] += accumulated - debt;
+        }
+        rewardDebt[linkToken][user] = accumulated;
+    }
+
+    function _syncUserDebt(address linkToken, address user) private {
+        uint256 balance = ILinkToken(linkToken).balanceOf(user);
+        RewardData storage data = rewardData[linkToken];
+        uint256 acc = data.accPerShare;
+        uint256 totalSupply = ILinkToken(linkToken).totalSupply();
+        if (totalSupply > 0 && data.queuedRewards > 0) {
+            acc += (data.queuedRewards * ACC_PRECISION) / totalSupply;
+        }
+        rewardDebt[linkToken][user] = (balance * acc) / ACC_PRECISION;
+    }
+
+    function _bumpHour(address linkToken, uint256 amount) private {
+        uint64 currentHour = uint64(block.timestamp / 1 hours);
+        hourlyRevenue[linkToken][currentHour] += amount;
+        lastRecordedHour[linkToken] = currentHour;
+    }
+}

--- a/contracts/interfaces/ILinkToken.sol
+++ b/contracts/interfaces/ILinkToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface ILinkToken {
+    function linkId() external view returns (bytes32);
+    function factory() external view returns (address);
+    function distributor() external view returns (address);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/contracts/interfaces/IRewardsDistributor.sol
+++ b/contracts/interfaces/IRewardsDistributor.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IRewardsDistributor {
+    function notifyReward(address linkToken, uint256 amount) external;
+    function updateUser(address linkToken, address user) external;
+    function afterTokenTransfer(address linkToken, address user) external;
+    function pendingRewards(address linkToken, address user) external view returns (uint256);
+    function claim(address linkToken, address to) external returns (uint256);
+    function claimBatch(address[] calldata linkTokens, address to) external returns (uint256);
+    function revenueLast24Hours(address linkToken) external view returns (uint256);
+    function setCampaigns(address campaigns_) external;
+}

--- a/contracts/libraries/ECDSA.sol
+++ b/contracts/libraries/ECDSA.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+library ECDSA {
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+        require(signature.length == 65, "ECDSA: invalid signature length");
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+
+        if (v < 27) {
+            v += 27;
+        }
+
+        require(v == 27 || v == 28, "ECDSA: invalid v value");
+
+        return ecrecover(hash, v, r, s);
+    }
+}

--- a/contracts/libraries/LinkCanonicalizer.sol
+++ b/contracts/libraries/LinkCanonicalizer.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+library LinkCanonicalizer {
+    bytes1 private constant LOWER_A = bytes1("a");
+    bytes1 private constant LOWER_Z = bytes1("z");
+    bytes1 private constant UPPER_A = bytes1("A");
+    bytes1 private constant UPPER_Z = bytes1("Z");
+
+    function canonicalize(string memory rawLink) internal pure returns (string memory) {
+        bytes memory input = bytes(rawLink);
+        if (input.length == 0) {
+            return "";
+        }
+
+        // Lowercase and trim whitespace
+        bytes memory lowered = _toLowerAndTrim(input);
+
+        // Split into base and query string
+        (bytes memory basePart, bytes memory query) = _splitQuery(lowered);
+
+        // Remove trailing slash on path (but keep root slash)
+        basePart = _stripTrailingSlash(basePart);
+
+        if (query.length == 0) {
+            return string(basePart);
+        }
+
+        bytes memory filtered = _filterUtmParams(query);
+        if (filtered.length == 0) {
+            return string(basePart);
+        }
+
+        return string(abi.encodePacked(basePart, "?", filtered));
+    }
+
+    function computeLinkId(string memory rawLink) internal pure returns (bytes32) {
+        return keccak256(bytes(canonicalize(rawLink)));
+    }
+
+    function _toLowerAndTrim(bytes memory input) private pure returns (bytes memory) {
+        uint256 start;
+        uint256 end = input.length;
+        while (start < input.length && _isWhitespace(input[start])) {
+            start++;
+        }
+        while (end > start && _isWhitespace(input[end - 1])) {
+            end--;
+        }
+        bytes memory output = new bytes(end - start);
+        for (uint256 i = start; i < end; i++) {
+            bytes1 char = input[i];
+            if (char >= UPPER_A && char <= UPPER_Z) {
+                output[i - start] = bytes1(uint8(char) + 32);
+            } else {
+                output[i - start] = char;
+            }
+        }
+        return output;
+    }
+
+    function _splitQuery(bytes memory value) private pure returns (bytes memory basePart, bytes memory query) {
+        for (uint256 i = 0; i < value.length; i++) {
+            if (value[i] == bytes1("?")) {
+                basePart = new bytes(i);
+                for (uint256 j = 0; j < i; j++) {
+                    basePart[j] = value[j];
+                }
+                uint256 queryLength = value.length - i - 1;
+                query = new bytes(queryLength);
+                for (uint256 j = 0; j < queryLength; j++) {
+                    query[j] = value[i + 1 + j];
+                }
+                return (basePart, query);
+            }
+        }
+        basePart = value;
+        return (basePart, query);
+    }
+
+    function _stripTrailingSlash(bytes memory basePart) private pure returns (bytes memory) {
+        if (basePart.length <= 1) {
+            return basePart;
+        }
+        if (basePart[basePart.length - 1] == bytes1("/")) {
+            bytes memory trimmed = new bytes(basePart.length - 1);
+            for (uint256 i = 0; i < trimmed.length; i++) {
+                trimmed[i] = basePart[i];
+            }
+            return trimmed;
+        }
+        return basePart;
+    }
+
+    function _filterUtmParams(bytes memory query) private pure returns (bytes memory) {
+        bytes memory buffer = new bytes(query.length);
+        uint256 bufferLength;
+        uint256 start;
+        while (start < query.length) {
+            uint256 end = start;
+            while (end < query.length && query[end] != bytes1("&")) {
+                end++;
+            }
+
+            bool isUtm = _startsWithUtm(query, start, end);
+            if (!isUtm) {
+                if (bufferLength > 0) {
+                    buffer[bufferLength++] = bytes1("&");
+                }
+                for (uint256 i = start; i < end; i++) {
+                    buffer[bufferLength++] = query[i];
+                }
+            }
+
+            start = end + 1;
+        }
+
+        bytes memory output = new bytes(bufferLength);
+        for (uint256 i = 0; i < bufferLength; i++) {
+            output[i] = buffer[i];
+        }
+        return output;
+    }
+
+    function _startsWithUtm(bytes memory query, uint256 start, uint256 end) private pure returns (bool) {
+        if (end <= start + 4) {
+            return false;
+        }
+        if (query[start] != bytes1("u") || query[start + 1] != bytes1("t") || query[start + 2] != bytes1("m") || query[start + 3] != bytes1("_")) {
+            return false;
+        }
+        return true;
+    }
+
+    function _isWhitespace(bytes1 char) private pure returns (bool) {
+        return char == 0x20 || char == 0x09 || char == 0x0d || char == 0x0a;
+    }
+}

--- a/contracts/libraries/SafeTransferLib.sol
+++ b/contracts/libraries/SafeTransferLib.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Errors} from "../utils/Errors.sol";
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function decimals() external view returns (uint8);
+}
+
+library SafeTransferLib {
+    function safeTransfer(IERC20 token, address to, uint256 value) internal {
+        require(_callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value)), Errors.INVALID_INPUT);
+    }
+
+    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
+        require(_callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value)), Errors.INVALID_INPUT);
+    }
+
+    function safeApprove(IERC20 token, address spender, uint256 value) internal {
+        require(_callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value)), Errors.INVALID_INPUT);
+    }
+
+    function _callOptionalReturn(IERC20 token, bytes memory data) private returns (bool) {
+        (bool success, bytes memory returndata) = address(token).call(data);
+        if (!success) {
+            if (returndata.length > 0) {
+                assembly {
+                    revert(add(32, returndata), mload(returndata))
+                }
+            }
+            return false;
+        }
+
+        if (returndata.length == 0) {
+            return true;
+        }
+
+        return abi.decode(returndata, (bool));
+    }
+}

--- a/contracts/utils/ERC20.sol
+++ b/contracts/utils/ERC20.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Errors} from "./Errors.sol";
+
+abstract contract ERC20 {
+    string public name;
+    string public symbol;
+    uint8 public immutable decimals;
+
+    mapping(address => uint256) internal _balances;
+    mapping(address => mapping(address => uint256)) internal _allowances;
+    uint256 internal _totalSupply;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        name = name_;
+        symbol = symbol_;
+        decimals = decimals_;
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) public view returns (uint256) {
+        return _balances[account];
+    }
+
+    function allowance(address owner, address spender) public view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function transfer(address to, uint256 value) public returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) public returns (bool) {
+        _approve(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) public returns (bool) {
+        uint256 allowed = _allowances[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            require(allowed >= value, Errors.INSUFFICIENT_ALLOWANCE);
+            unchecked {
+                _allowances[from][msg.sender] = allowed - value;
+            }
+        }
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        require(to != address(0), Errors.ZERO_ADDRESS);
+        uint256 balance = _balances[from];
+        require(balance >= value, Errors.INSUFFICIENT_BALANCE);
+        _beforeTokenTransfer(from, to, value);
+        unchecked {
+            _balances[from] = balance - value;
+            _balances[to] += value;
+        }
+        emit Transfer(from, to, value);
+        _afterTokenTransfer(from, to, value);
+    }
+
+    function _mint(address to, uint256 value) internal {
+        require(to != address(0), Errors.ZERO_ADDRESS);
+        _beforeTokenTransfer(address(0), to, value);
+        _totalSupply += value;
+        _balances[to] += value;
+        emit Transfer(address(0), to, value);
+        _afterTokenTransfer(address(0), to, value);
+    }
+
+    function _burn(address from, uint256 value) internal {
+        uint256 balance = _balances[from];
+        require(balance >= value, Errors.INSUFFICIENT_BALANCE);
+        _beforeTokenTransfer(from, address(0), value);
+        unchecked {
+            _balances[from] = balance - value;
+        }
+        _totalSupply -= value;
+        emit Transfer(from, address(0), value);
+        _afterTokenTransfer(from, address(0), value);
+    }
+
+    function _approve(address owner, address spender, uint256 value) internal {
+        require(owner != address(0) && spender != address(0), Errors.ZERO_ADDRESS);
+        _allowances[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 value) internal virtual {}
+
+    function _afterTokenTransfer(address from, address to, uint256 value) internal virtual {}
+}

--- a/contracts/utils/Errors.sol
+++ b/contracts/utils/Errors.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+library Errors {
+    string internal constant ZERO_ADDRESS = "ZERO_ADDRESS";
+    string internal constant INVALID_INPUT = "INVALID_INPUT";
+    string internal constant UNAUTHORIZED = "UNAUTHORIZED";
+    string internal constant INSUFFICIENT_BALANCE = "INSUFFICIENT_BALANCE";
+    string internal constant INSUFFICIENT_ALLOWANCE = "INSUFFICIENT_ALLOWANCE";
+    string internal constant OVERFLOW = "OVERFLOW";
+    string internal constant CAMPAIGN_NOT_ACTIVE = "CAMPAIGN_NOT_ACTIVE";
+    string internal constant CAMPAIGN_CLOSED = "CAMPAIGN_CLOSED";
+    string internal constant CPC_OUT_OF_BOUNDS = "CPC_OUT_OF_BOUNDS";
+    string internal constant CLICK_ALREADY_CONSUMED = "CLICK_ALREADY_CONSUMED";
+    string internal constant TIMESTAMP_OUT_OF_RANGE = "TIMESTAMP_OUT_OF_RANGE";
+    string internal constant INSUFFICIENT_REMAINING_BUDGET = "INSUFFICIENT_REMAINING_BUDGET";
+    string internal constant NO_SUPPLY = "NO_SUPPLY";
+}

--- a/src/lib/blockchain/abi.ts
+++ b/src/lib/blockchain/abi.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+import { concatHex, padHex } from '$lib/utils/hex';
+import { keccak256Hex, utf8ToBytes } from '$lib/crypto/keccak';
+
+export type AbiType = 'uint256' | 'bytes32' | 'address' | 'bool' | 'string' | 'address[]';
+
+export interface AbiFunction {
+	readonly name: string;
+	readonly signature: string;
+	readonly inputs: readonly AbiType[];
+	readonly outputs: readonly AbiType[];
+}
+
+const ADDRESS_LENGTH = 20;
+const WORD_SIZE = 32;
+
+function encodeUint256(value: bigint | number | string): string {
+	const big = typeof value === 'bigint' ? value : BigInt(value);
+	const hex = big.toString(16);
+	return padHex(`0x${hex}`, WORD_SIZE);
+}
+
+function encodeBool(value: boolean): string {
+	return padHex(value ? '0x1' : '0x0', WORD_SIZE);
+}
+
+function encodeAddress(value: string): string {
+	const sanitized = value.toLowerCase().replace(/^0x/, '');
+	if (sanitized.length !== ADDRESS_LENGTH * 2) {
+		throw new Error('Invalid address length');
+	}
+	return padHex(`0x${sanitized}`, WORD_SIZE);
+}
+
+function encodeBytes32(value: string): string {
+	const sanitized = value.replace(/^0x/, '');
+	if (sanitized.length !== 64) {
+		throw new Error('Invalid bytes32 length');
+	}
+	return sanitized;
+}
+
+function encodeString(value: string): { head: string; tail: string } {
+	const bytes = utf8ToBytes(value);
+	const lengthEncoded = encodeUint256(bytes.length);
+	const padding = (WORD_SIZE - (bytes.length % WORD_SIZE)) % WORD_SIZE;
+	const dataHex = `${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}${'00'.repeat(padding)}`;
+	return { head: lengthEncoded, tail: dataHex };
+}
+
+export function functionSelector(signature: string): string {
+	return keccak256Hex(utf8ToBytes(signature)).slice(0, 10);
+}
+
+export function encodeCallData(fn: AbiFunction, args: readonly unknown[]): string {
+	if (args.length !== fn.inputs.length) {
+		throw new Error('Invalid argument length');
+	}
+	const head: string[] = [];
+	const tail: string[] = [];
+	let dynamicOffset = WORD_SIZE * fn.inputs.length;
+	fn.inputs.forEach((type, index) => {
+		const value = args[index];
+		switch (type) {
+			case 'uint256':
+				head.push(encodeUint256(value as bigint | number | string));
+				break;
+			case 'bool':
+				head.push(encodeBool(Boolean(value)));
+				break;
+			case 'address':
+				head.push(encodeAddress(value as string));
+				break;
+			case 'bytes32':
+				head.push(encodeBytes32(value as string));
+				break;
+			case 'string': {
+				head.push(encodeUint256(dynamicOffset));
+				const encoded = encodeString(value as string);
+				tail.push(encoded.head + encoded.tail);
+				dynamicOffset += WORD_SIZE + encoded.tail.length / 2;
+				break;
+			}
+			case 'address[]': {
+				head.push(encodeUint256(dynamicOffset));
+				const addresses = (value as string[]) ?? [];
+				const lengthEncoded = encodeUint256(addresses.length);
+				const encodedItems = addresses.map((item) => encodeAddress(item)).join('');
+				tail.push(lengthEncoded + encodedItems);
+				dynamicOffset += WORD_SIZE + addresses.length * WORD_SIZE;
+				break;
+			}
+			default:
+				throw new Error(`Unsupported type: ${type}`);
+		}
+	});
+	const selector = functionSelector(fn.signature);
+	return concatHex(selector, head.join(''), tail.join(''));
+}
+
+function readWord(data: string, index: number): string {
+	const offset = 2 + index * WORD_SIZE * 2;
+	return data.slice(offset, offset + WORD_SIZE * 2);
+}
+
+function decodeUint256(hex: string): bigint {
+	return BigInt(`0x${hex}`);
+}
+
+function decodeBool(hex: string): boolean {
+	return hex.endsWith('1');
+}
+
+function decodeAddress(hex: string): string {
+	return `0x${hex.slice(24)}`;
+}
+
+function decodeBytes32(hex: string): string {
+	return `0x${hex}`;
+}
+
+function decodeString(data: string, offsetWord: string): string {
+	const offset = Number(decodeUint256(offsetWord));
+	const start = 2 + offset * 2;
+	const lengthHex = data.slice(start, start + WORD_SIZE * 2);
+	const length = Number(decodeUint256(lengthHex));
+	const contentStart = start + WORD_SIZE * 2;
+	const contentHex = data.slice(contentStart, contentStart + length * 2);
+	let result = '';
+	for (let i = 0; i < contentHex.length; i += 2) {
+		result += String.fromCharCode(parseInt(contentHex.slice(i, i + 2), 16));
+	}
+	return result;
+}
+
+function decodeAddressArray(data: string, offsetWord: string): string[] {
+	const offset = Number(decodeUint256(offsetWord));
+	const start = 2 + offset * 2;
+	const lengthHex = data.slice(start, start + WORD_SIZE * 2);
+	const length = Number(decodeUint256(lengthHex));
+	const result: string[] = [];
+	let cursor = start + WORD_SIZE * 2;
+	for (let i = 0; i < length; i++) {
+		const segment = data.slice(cursor, cursor + WORD_SIZE * 2);
+		result.push(decodeAddress(segment));
+		cursor += WORD_SIZE * 2;
+	}
+	return result;
+}
+
+export function decodeResult(fn: AbiFunction, data: string): unknown[] {
+	if (!data || data === '0x') return [];
+	const values: unknown[] = [];
+	fn.outputs.forEach((type, index) => {
+		const word = readWord(data, index);
+		switch (type) {
+			case 'uint256':
+				values.push(decodeUint256(word));
+				break;
+			case 'bool':
+				values.push(decodeBool(word));
+				break;
+			case 'address':
+				values.push(decodeAddress(word));
+				break;
+			case 'bytes32':
+				values.push(decodeBytes32(word));
+				break;
+			case 'string':
+				values.push(decodeString(data, word));
+				break;
+			case 'address[]':
+				values.push(decodeAddressArray(data, word));
+				break;
+			default:
+				throw new Error(`Unsupported type: ${type}`);
+		}
+	});
+	return values;
+}

--- a/src/lib/blockchain/contracts.ts
+++ b/src/lib/blockchain/contracts.ts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+import type { AbiFunction } from './abi';
+import { ethCall, ethSendTransaction } from './rpc';
+
+export interface ContractFunction {
+	readonly abi: AbiFunction;
+	readonly address: string;
+}
+
+interface DappContracts {
+	address: string;
+	distributor: string;
+	adCampaigns: string;
+}
+
+export const CONTRACTS: DappContracts = {
+	address: import.meta.env.VITE_FACTORY_ADDRESS ?? '0x0000000000000000000000000000000000000000',
+	distributor:
+		import.meta.env.VITE_DISTRIBUTOR_ADDRESS ?? '0x0000000000000000000000000000000000000000',
+	adCampaigns:
+		import.meta.env.VITE_AD_CAMPAIGNS_ADDRESS ?? '0x0000000000000000000000000000000000000000'
+};
+
+export const FACTORY_FUNCTIONS = {
+	getLinkToken: {
+		abi: {
+			name: 'getLinkToken',
+			signature: 'getLinkToken(bytes32)',
+			inputs: ['bytes32'],
+			outputs: ['address']
+		},
+		address: CONTRACTS.address
+	},
+	getOrCreateLinkToken: {
+		abi: {
+			name: 'getOrCreateLinkToken',
+			signature: 'getOrCreateLinkToken(bytes32,string,string)',
+			inputs: ['bytes32', 'string', 'string'],
+			outputs: ['address']
+		},
+		address: CONTRACTS.address
+	},
+	purchase: {
+		abi: {
+			name: 'purchase',
+			signature: 'purchase(bytes32,uint256,address)',
+			inputs: ['bytes32', 'uint256', 'address'],
+			outputs: []
+		},
+		address: CONTRACTS.address
+	},
+	tokenPrice: {
+		abi: {
+			name: 'tokenPrice',
+			signature: 'tokenPrice()',
+			inputs: [],
+			outputs: ['uint256']
+		},
+		address: CONTRACTS.address
+	},
+	getAllLinkTokens: {
+		abi: {
+			name: 'getAllLinkTokens',
+			signature: 'getAllLinkTokens()',
+			inputs: [],
+			outputs: ['address[]']
+		},
+		address: CONTRACTS.address
+	}
+} satisfies Record<string, ContractFunction>;
+
+export const DISTRIBUTOR_FUNCTIONS = {
+	pendingRewards: {
+		abi: {
+			name: 'pendingRewards',
+			signature: 'pendingRewards(address,address)',
+			inputs: ['address', 'address'],
+			outputs: ['uint256']
+		},
+		address: CONTRACTS.distributor
+	},
+	claim: {
+		abi: {
+			name: 'claim',
+			signature: 'claim(address,address)',
+			inputs: ['address', 'address'],
+			outputs: ['uint256']
+		},
+		address: CONTRACTS.distributor
+	},
+	claimBatch: {
+		abi: {
+			name: 'claimBatch',
+			signature: 'claimBatch(address[],address)',
+			inputs: ['address[]', 'address'],
+			outputs: ['uint256']
+		},
+		address: CONTRACTS.distributor
+	},
+	revenue24h: {
+		abi: {
+			name: 'revenueLast24Hours',
+			signature: 'revenueLast24Hours(address)',
+			inputs: ['address'],
+			outputs: ['uint256']
+		},
+		address: CONTRACTS.distributor
+	}
+} satisfies Record<string, ContractFunction>;
+
+export const AD_CAMPAIGNS_FUNCTIONS = {
+	createCampaign: {
+		abi: {
+			name: 'createCampaign',
+			signature: 'createCampaign(bytes32,bytes32,address,uint256,uint256)',
+			inputs: ['bytes32', 'bytes32', 'address', 'uint256', 'uint256'],
+			outputs: ['uint256']
+		},
+		address: CONTRACTS.adCampaigns
+	},
+	campaigns: {
+		abi: {
+			name: 'campaigns',
+			signature: 'campaigns(uint256)',
+			inputs: ['uint256'],
+			outputs: [
+				'address',
+				'bytes32',
+				'bytes32',
+				'address',
+				'uint256',
+				'uint256',
+				'uint256',
+				'uint256',
+				'bool',
+				'bool'
+			]
+		},
+		address: CONTRACTS.adCampaigns
+	},
+	fundCampaign: {
+		abi: {
+			name: 'fundCampaign',
+			signature: 'fundCampaign(uint256,uint256)',
+			inputs: ['uint256', 'uint256'],
+			outputs: []
+		},
+		address: CONTRACTS.adCampaigns
+	},
+	pauseCampaign: {
+		abi: {
+			name: 'pauseCampaign',
+			signature: 'pauseCampaign(uint256,bool)',
+			inputs: ['uint256', 'bool'],
+			outputs: []
+		},
+		address: CONTRACTS.adCampaigns
+	},
+	closeCampaign: {
+		abi: {
+			name: 'closeCampaign',
+			signature: 'closeCampaign(uint256,address)',
+			inputs: ['uint256', 'address'],
+			outputs: []
+		},
+		address: CONTRACTS.adCampaigns
+	},
+	remainingBudget: {
+		abi: {
+			name: 'remainingBudget',
+			signature: 'remainingBudget(uint256)',
+			inputs: ['uint256'],
+			outputs: ['uint256']
+		},
+		address: CONTRACTS.adCampaigns
+	}
+} satisfies Record<string, ContractFunction>;
+
+const LINK_TOKEN_ABI: Record<string, AbiFunction> = {
+	totalSupply: {
+		name: 'totalSupply',
+		signature: 'totalSupply()',
+		inputs: [],
+		outputs: ['uint256']
+	},
+	balanceOf: {
+		name: 'balanceOf',
+		signature: 'balanceOf(address)',
+		inputs: ['address'],
+		outputs: ['uint256']
+	}
+};
+
+export function linkTokenFunction(
+	address: string,
+	key: keyof typeof LINK_TOKEN_ABI
+): ContractFunction {
+	return {
+		abi: LINK_TOKEN_ABI[key],
+		address
+	};
+}
+
+export async function readContract(fn: ContractFunction, args: unknown[] = []): Promise<unknown[]> {
+	return ethCall(fn.address, fn.abi, args);
+}
+
+export async function writeContract(
+	from: string,
+	fn: ContractFunction,
+	args: unknown[] = []
+): Promise<string> {
+	return ethSendTransaction(from, fn.address, fn.abi, args);
+}

--- a/src/lib/blockchain/rpc.ts
+++ b/src/lib/blockchain/rpc.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+import type { AbiFunction } from './abi';
+import { encodeCallData, decodeResult } from './abi';
+
+export async function request<T = unknown>(method: string, params: unknown[]): Promise<T> {
+	const { ethereum } = window as typeof window & {
+		ethereum?: { request: (args: { method: string; params?: unknown[] }) => Promise<T> };
+	};
+	if (!ethereum) {
+		throw new Error('Wallet not detected');
+	}
+	return ethereum.request({ method, params });
+}
+
+export async function ethCall(
+	address: string,
+	fn: AbiFunction,
+	args: unknown[]
+): Promise<unknown[]> {
+	const data = encodeCallData(fn, args);
+	const result = await request<string>('eth_call', [{ to: address, data }, 'latest']);
+	return decodeResult(fn, result);
+}
+
+export async function ethSendTransaction(
+	from: string,
+	address: string,
+	fn: AbiFunction,
+	args: unknown[]
+): Promise<string> {
+	const data = encodeCallData(fn, args);
+	return request<string>('eth_sendTransaction', [{ from, to: address, data }]);
+}
+
+export async function getChainId(): Promise<number> {
+	const hexChainId = await request<string>('eth_chainId', []);
+	return Number.parseInt(hexChainId, 16);
+}
+
+export async function getAccounts(): Promise<string[]> {
+	try {
+		return await request<string[]>('eth_accounts', []);
+	} catch {
+		return [];
+	}
+}
+
+export async function requestAccounts(): Promise<string[]> {
+	return request<string[]>('eth_requestAccounts', []);
+}

--- a/src/lib/blockchain/wallet.ts
+++ b/src/lib/blockchain/wallet.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+import { writable } from 'svelte/store';
+import { getAccounts, getChainId, requestAccounts } from './rpc';
+
+export const account = writable<string | null>(null);
+export const chainId = writable<number | null>(null);
+
+export async function initializeWallet(): Promise<void> {
+	if (typeof window === 'undefined') return;
+	const accounts = await getAccounts();
+	account.set(accounts[0] ?? null);
+	try {
+		const id = await getChainId();
+		chainId.set(id);
+	} catch {
+		chainId.set(null);
+	}
+	const { ethereum } = window as typeof window & { ethereum?: any };
+	if (ethereum?.on) {
+		ethereum.on('accountsChanged', (accs: string[]) => {
+			account.set(accs[0] ?? null);
+		});
+		ethereum.on('chainChanged', (chain: string) => {
+			chainId.set(Number.parseInt(chain, 16));
+		});
+	}
+}
+
+export async function connectWallet(): Promise<string | null> {
+	const accounts = await requestAccounts();
+	const selected = accounts[0] ?? null;
+	account.set(selected);
+	if (selected) {
+		const id = await getChainId();
+		chainId.set(id);
+	}
+	return selected;
+}
+
+export function disconnectWallet(): void {
+	account.set(null);
+}

--- a/src/lib/components/ConnectWallet.svelte
+++ b/src/lib/components/ConnectWallet.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { account, connectWallet, disconnectWallet } from '$lib/blockchain/wallet';
+	import { onMount } from 'svelte';
+	import { initializeWallet } from '$lib/blockchain/wallet';
+
+	let isConnecting = false;
+
+	onMount(() => {
+		initializeWallet();
+	});
+
+	async function handleConnect() {
+		if (isConnecting) return;
+		isConnecting = true;
+		try {
+			await connectWallet();
+		} catch (error) {
+			console.error('Failed to connect wallet', error);
+		} finally {
+			isConnecting = false;
+		}
+	}
+
+	function handleDisconnect() {
+		disconnectWallet();
+	}
+</script>
+
+{#if $account}
+	<div class="flex items-center gap-2">
+		<span class="rounded bg-emerald-900/40 px-3 py-1 font-mono text-sm text-emerald-200">
+			{$account.slice(0, 6)}…{$account.slice(-4)}
+		</span>
+		<button
+			class="rounded bg-zinc-700 px-3 py-1 text-sm hover:bg-zinc-600"
+			on:click={handleDisconnect}
+		>
+			Disconnect
+		</button>
+	</div>
+{:else}
+	<button
+		class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-60"
+		on:click={handleConnect}
+		disabled={isConnecting}
+	>
+		{isConnecting ? 'Connecting…' : 'Connect Wallet'}
+	</button>
+{/if}

--- a/src/lib/crypto/keccak.ts
+++ b/src/lib/crypto/keccak.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+
+const ROUND_CONSTANTS: bigint[] = [
+	0x0000000000000001n,
+	0x0000000000008082n,
+	0x800000000000808an,
+	0x8000000080008000n,
+	0x000000000000808bn,
+	0x0000000080000001n,
+	0x8000000080008081n,
+	0x8000000000008009n,
+	0x000000000000008an,
+	0x0000000000000088n,
+	0x0000000080008009n,
+	0x000000008000000an,
+	0x000000008000808bn,
+	0x800000000000008bn,
+	0x8000000000008089n,
+	0x8000000000008003n,
+	0x8000000000008002n,
+	0x8000000000000080n,
+	0x000000000000800an,
+	0x800000008000000an,
+	0x8000000080008081n,
+	0x8000000000008080n,
+	0x0000000080000001n,
+	0x8000000080008008n
+];
+
+const ROTATION_OFFSETS: number[][] = [
+	[0, 36, 3, 41, 18],
+	[1, 44, 10, 45, 2],
+	[62, 6, 43, 15, 61],
+	[28, 55, 25, 21, 56],
+	[27, 20, 39, 8, 14]
+];
+
+const MASK = (1n << 64n) - 1n;
+const RATE = 136;
+
+function rotl(value: bigint, shift: number): bigint {
+	shift %= 64;
+	if (shift === 0) return value;
+	return ((value << BigInt(shift)) & MASK) | (value >> BigInt(64 - shift));
+}
+
+function keccakF(state: BigUint64Array): void {
+	const C = new BigUint64Array(5);
+	const D = new BigUint64Array(5);
+	const temp = new BigUint64Array(25);
+	for (let round = 0; round < 24; round++) {
+		for (let x = 0; x < 5; x++) {
+			C[x] = state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20];
+		}
+		for (let x = 0; x < 5; x++) {
+			D[x] = C[(x + 4) % 5] ^ rotl(C[(x + 1) % 5], 1);
+		}
+		for (let x = 0; x < 5; x++) {
+			for (let y = 0; y < 5; y++) {
+				const index = x + 5 * y;
+				state[index] ^= D[x];
+			}
+		}
+
+		for (let x = 0; x < 5; x++) {
+			for (let y = 0; y < 5; y++) {
+				const index = x + 5 * y;
+				const shift = ROTATION_OFFSETS[y][x];
+				const newX = y;
+				const newY = (2 * x + 3 * y) % 5;
+				temp[newX + 5 * newY] = rotl(state[index], shift);
+			}
+		}
+
+		for (let x = 0; x < 5; x++) {
+			for (let y = 0; y < 5; y++) {
+				const index = x + 5 * y;
+				state[index] = temp[index] ^ (~temp[((x + 1) % 5) + 5 * y] & temp[((x + 2) % 5) + 5 * y]);
+			}
+		}
+
+		state[0] ^= ROUND_CONSTANTS[round];
+	}
+}
+
+function padInput(input: Uint8Array): Uint8Array {
+	const lengthWithPadding = input.length + 1;
+	const remainder = lengthWithPadding % RATE;
+	const paddingSize = remainder === 0 ? RATE : RATE - remainder;
+	const output = new Uint8Array(lengthWithPadding + paddingSize);
+	output.set(input, 0);
+	output[input.length] = 0x01;
+	output[output.length - 1] ^= 0x80;
+	return output;
+}
+
+function absorb(state: BigUint64Array, block: Uint8Array): void {
+	for (let i = 0; i < RATE / 8; i++) {
+		let value = 0n;
+		for (let j = 0; j < 8; j++) {
+			value |= BigInt(block[i * 8 + j]) << BigInt(8 * j);
+		}
+		state[i] ^= value;
+	}
+	keccakF(state);
+}
+
+function squeeze(state: BigUint64Array, outputLength: number): Uint8Array {
+	const output = new Uint8Array(outputLength);
+	let offset = 0;
+	while (offset < outputLength) {
+		for (let i = 0; i < RATE / 8 && offset < outputLength; i++) {
+			let lane = state[i];
+			for (let j = 0; j < 8 && offset < outputLength; j++) {
+				output[offset++] = Number(lane & 0xffn);
+				lane >>= 8n;
+			}
+		}
+		if (offset < outputLength) {
+			keccakF(state);
+		}
+	}
+	return output;
+}
+
+export function keccak256(data: Uint8Array): Uint8Array {
+	const state = new BigUint64Array(25);
+	const padded = padInput(data);
+	for (let offset = 0; offset < padded.length; offset += RATE) {
+		absorb(state, padded.subarray(offset, offset + RATE));
+	}
+	return squeeze(state, 32);
+}
+
+export function keccak256Hex(data: Uint8Array | string): string {
+	const bytes = typeof data === 'string' ? utf8ToBytes(data) : data;
+	const digest = keccak256(bytes);
+	return `0x${Array.from(digest, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+export function utf8ToBytes(value: string): Uint8Array {
+	const encoder = new TextEncoder();
+	return encoder.encode(value);
+}

--- a/src/lib/utils/bytes32.ts
+++ b/src/lib/utils/bytes32.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+import { keccak256Hex, utf8ToBytes } from '$lib/crypto/keccak';
+
+export function toBytes32(value: string): string {
+	if (!value) return '0x' + '00'.repeat(32);
+	if (value.startsWith('0x')) {
+		const sanitized = value.slice(2);
+		if (sanitized.length > 64) {
+			throw new Error('Hex string too long for bytes32');
+		}
+		return `0x${sanitized.padStart(64, '0')}`;
+	}
+	return keccak256Hex(utf8ToBytes(value));
+}

--- a/src/lib/utils/canonicalize-link.ts
+++ b/src/lib/utils/canonicalize-link.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+import { keccak256Hex, utf8ToBytes } from '$lib/crypto/keccak';
+
+function trimWhitespace(input: string): string {
+	return input.trim();
+}
+
+function toLowercase(input: string): string {
+	return input.toLowerCase();
+}
+
+function stripTrailingSlash(path: string): string {
+	if (path.length <= 1) return path;
+	return path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
+function filterUtmParams(query: string): string {
+	if (!query) return '';
+	const params = query.split('&').filter((part) => part && !part.startsWith('utm_'));
+	return params.join('&');
+}
+
+export function canonicalizeLink(rawLink: string): string {
+	const trimmed = trimWhitespace(rawLink);
+	if (!trimmed) return '';
+	const lowered = toLowercase(trimmed);
+	const [base, query = ''] = lowered.split('?');
+	const normalizedBase = stripTrailingSlash(base);
+	const filteredQuery = filterUtmParams(query);
+	return filteredQuery ? `${normalizedBase}?${filteredQuery}` : normalizedBase;
+}
+
+export function linkIdFromCanonicalLink(canonicalLink: string): string {
+	return keccak256Hex(utf8ToBytes(canonicalLink));
+}
+
+export function linkIdFromRawLink(rawLink: string): { canonical: string; linkId: string } {
+	const canonical = canonicalizeLink(rawLink);
+	const linkId = linkIdFromCanonicalLink(canonical);
+	return { canonical, linkId };
+}

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+const TEN = 10n;
+
+export function formatUnits(value: bigint, decimals: number, precision = 4): string {
+	if (decimals === 0) return value.toString();
+	const base = TEN ** BigInt(decimals);
+	const integer = value / base;
+	const fraction = value % base;
+	if (fraction === 0n) {
+		return integer.toString();
+	}
+	const fractionStr = (fraction + base).toString().slice(1).padStart(decimals, '0');
+	const truncated = fractionStr.slice(0, precision).replace(/0+$/, '');
+	return truncated ? `${integer.toString()}.${truncated}` : integer.toString();
+}
+
+export function parseUnits(value: string, decimals: number): bigint {
+	const [whole, fraction = ''] = value.split('.');
+	const sanitizedWhole = whole.replace(/_/g, '');
+	const sanitizedFraction = fraction.replace(/_/g, '');
+	const base = TEN ** BigInt(decimals);
+	let result = BigInt(sanitizedWhole || '0') * base;
+	if (sanitizedFraction) {
+		const padded = (sanitizedFraction + '0'.repeat(decimals)).slice(0, decimals);
+		result += BigInt(padded);
+	}
+	return result;
+}
+
+export function formatUSD(value: bigint): string {
+	return `$${formatUnits(value, 6, 2)}`;
+}
+
+export function formatPercent(numerator: bigint, denominator: bigint): string {
+	if (denominator === 0n) return '0%';
+	const scale = 10_000n;
+	const ratio = (numerator * scale * 100n) / denominator;
+	const whole = ratio / scale;
+	const fractional = ratio % scale;
+	const fractionStr = fractional.toString().padStart(4, '0').replace(/0+$/, '');
+	return fractionStr ? `${whole}.${fractionStr}%` : `${whole}%`;
+}

--- a/src/lib/utils/hex.ts
+++ b/src/lib/utils/hex.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+export function padHex(value: string, length: number): string {
+	const sanitized = value.startsWith('0x') ? value.slice(2) : value;
+	return sanitized.padStart(length * 2, '0');
+}
+
+export function toHex(bytes: Uint8Array): string {
+	return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+	const sanitized = hex.startsWith('0x') ? hex.slice(2) : hex;
+	const array = new Uint8Array(sanitized.length / 2);
+	for (let i = 0; i < array.length; i++) {
+		array[i] = parseInt(sanitized.slice(i * 2, i * 2 + 2), 16);
+	}
+	return array;
+}
+
+export function concatHex(...parts: string[]): string {
+	return `0x${parts.map((p) => (p.startsWith('0x') ? p.slice(2) : p)).join('')}`;
+}
+
+export function numberToHex(value: bigint | number): string {
+	const big = typeof value === 'bigint' ? value : BigInt(value);
+	return big.toString(16);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,44 @@
 <script lang="ts">
 	import '../app.css';
 	import favicon from '$lib/assets/favicon.svg';
+	import ConnectWallet from '$lib/components/ConnectWallet.svelte';
 
 	let { children } = $props();
 </script>
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
+	<title>Farcaster Link Rewards</title>
 </svelte:head>
 
-{@render children?.()}
+<div class="min-h-screen bg-zinc-950 text-zinc-100">
+	<header class="border-b border-zinc-800 bg-zinc-900/60 backdrop-blur">
+		<div
+			class="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between"
+		>
+			<div>
+				<h1 class="text-2xl font-semibold">Farcaster Link Rewards</h1>
+				<p class="text-sm text-zinc-400">
+					Tokenize attention. Reward curators. Settle clicks on Base.
+				</p>
+			</div>
+			<div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+				<nav class="flex items-center gap-4 text-sm text-zinc-300">
+					<a class="hover:text-white" href="/">Overview</a>
+					<a class="hover:text-white" href="/buy">Buy</a>
+					<a class="hover:text-white" href="/advertise">Advertise</a>
+					<a class="hover:text-white" href="/claim">Claim</a>
+				</nav>
+				<ConnectWallet />
+			</div>
+		</div>
+	</header>
+	<main class="mx-auto max-w-6xl px-6 py-10">
+		{@render children?.()}
+	</main>
+	<footer class="border-t border-zinc-900 bg-zinc-950/80">
+		<div class="mx-auto max-w-6xl px-6 py-6 text-sm text-zinc-500">
+			Built for Base • Signed clicks only • Rewards flow continuously.
+		</div>
+	</footer>
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,48 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<section class="grid gap-10 lg:grid-cols-2">
+	<article class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-8 shadow-lg shadow-black/20">
+		<h2 class="text-xl font-semibold text-white">On-chain revenue sharing for Farcaster links</h2>
+		<p class="mt-4 text-zinc-400">
+			Every Farcaster cast or URL mints its own ERC-20 “link token”. Holders of that token earn USDC
+			every time a verified ad click is recorded for the linked cast. Advertisers fund campaigns
+			with USDC on Base and each click settles instantly into the token’s reward pool.
+		</p>
+		<ul class="mt-6 space-y-3 text-sm text-zinc-300">
+			<li>• Deterministic link IDs using canonicalized URLs.</li>
+			<li>• Trusted attesters sign valid clicks; duplicates are rejected on-chain.</li>
+			<li>• Rewards accumulate continuously and can be claimed anytime.</li>
+		</ul>
+		<div class="mt-8 flex gap-3">
+			<a
+				href="/buy"
+				class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+				>Buy link tokens</a
+			>
+			<a
+				href="/advertise"
+				class="rounded border border-indigo-500/60 px-4 py-2 text-sm font-medium text-indigo-200 hover:bg-indigo-500/10"
+				>Fund a campaign</a
+			>
+		</div>
+	</article>
+	<article class="rounded-2xl border border-zinc-800 bg-zinc-900/20 p-8">
+		<h3 class="text-lg font-semibold text-white">How it works</h3>
+		<ol class="mt-4 space-y-4 text-sm text-zinc-300">
+			<li>
+				<span class="font-medium text-white">1. Tokenize links.</span> Anyone can register a canonical
+				link and mint its link token via the factory.
+			</li>
+			<li>
+				<span class="font-medium text-white">2. Fund CPC campaigns.</span> Advertisers escrow USDC with
+				a target link and cost-per-click bounds.
+			</li>
+			<li>
+				<span class="font-medium text-white">3. Validate clicks.</span> Off-chain attesters sign click
+				payloads that the contract checks for freshness, attester approval and duplicate prevention.
+			</li>
+			<li>
+				<span class="font-medium text-white">4. Claim rewards.</span> Link token holders pull their accrued
+				USDC whenever they want.
+			</li>
+		</ol>
+	</article>
+</section>

--- a/src/routes/advertise/+page.svelte
+++ b/src/routes/advertise/+page.svelte
@@ -1,0 +1,436 @@
+<script lang="ts">
+	import { account } from '$lib/blockchain/wallet';
+	import { linkIdFromRawLink } from '$lib/utils/canonicalize-link';
+	import { toBytes32 } from '$lib/utils/bytes32';
+	import { formatUSD, parseUnits } from '$lib/utils/format';
+	import {
+		FACTORY_FUNCTIONS,
+		DISTRIBUTOR_FUNCTIONS,
+		AD_CAMPAIGNS_FUNCTIONS,
+		readContract,
+		writeContract,
+		CONTRACTS
+	} from '$lib/blockchain/contracts';
+
+	interface CampaignState {
+		advertiser: string;
+		adId: string;
+		linkId: string;
+		linkToken: string;
+		cpc: bigint;
+		deposited: bigint;
+		spent: bigint;
+		clicks: bigint;
+		paused: boolean;
+		closed: boolean;
+		remaining: bigint;
+	}
+
+	let rawLink = '';
+	let canonicalLink = '';
+	let linkId = '';
+	let linkTokenAddress: string | null = null;
+	let adIdInput = '';
+	let cpcInput = '';
+	let budgetInput = '';
+	let createStatus = '';
+	let manageStatus = '';
+	let createdCampaignTx: string | null = null;
+	let lookupCampaignId = '';
+	let campaign: CampaignState | null = null;
+	let topLineRevenue = 0n;
+	let isBusy = false;
+	let fundInput = '';
+
+	function computeCanonical() {
+		if (!rawLink) {
+			canonicalLink = '';
+			linkId = '';
+			return;
+		}
+		const { canonical, linkId: computedId } = linkIdFromRawLink(rawLink);
+		canonicalLink = canonical;
+		linkId = computedId;
+	}
+
+	async function lookupLinkToken() {
+		computeCanonical();
+		if (!linkId) {
+			linkTokenAddress = null;
+			return;
+		}
+		const [address] = (await readContract(FACTORY_FUNCTIONS.getLinkToken, [linkId])) as [string];
+		linkTokenAddress = address !== '0x0000000000000000000000000000000000000000' ? address : null;
+	}
+
+	async function ensureLinkToken() {
+		await lookupLinkToken();
+		if (!linkTokenAddress && $account) {
+			if (
+				!CONTRACTS.address ||
+				CONTRACTS.address === '0x0000000000000000000000000000000000000000'
+			) {
+				throw new Error('Factory address missing. Set VITE_FACTORY_ADDRESS.');
+			}
+			await writeContract($account, FACTORY_FUNCTIONS.getOrCreateLinkToken, [
+				linkId,
+				canonicalLink,
+				'LINK'
+			]);
+			await lookupLinkToken();
+		}
+	}
+
+	async function handleCreateCampaign() {
+		computeCanonical();
+		if (!$account) {
+			createStatus = 'Connect your wallet to create a campaign.';
+			return;
+		}
+		if (!linkId) {
+			createStatus = 'Provide a valid link.';
+			return;
+		}
+		try {
+			isBusy = true;
+			await ensureLinkToken();
+			if (!linkTokenAddress) {
+				throw new Error('Unable to find or deploy link token.');
+			}
+			const adId = toBytes32(adIdInput || canonicalLink);
+			const cpc = parseUnits(cpcInput || '0', 6);
+			const deposit = parseUnits(budgetInput || '0', 6);
+			if (cpc === 0n || deposit === 0n) {
+				throw new Error('Set CPC and initial budget (in USDC).');
+			}
+			createStatus = 'Submitting campaign…';
+			const tx = await writeContract($account, AD_CAMPAIGNS_FUNCTIONS.createCampaign, [
+				adId,
+				linkId,
+				linkTokenAddress,
+				cpc,
+				deposit
+			]);
+			createdCampaignTx = tx;
+			createStatus = `Campaign transaction submitted: ${tx}`;
+		} catch (error) {
+			console.error(error);
+			createStatus = error instanceof Error ? error.message : 'Failed to create campaign';
+		} finally {
+			isBusy = false;
+		}
+	}
+
+	async function loadCampaign() {
+		manageStatus = '';
+		if (!lookupCampaignId) {
+			manageStatus = 'Enter a campaign id to load.';
+			return;
+		}
+		try {
+			const id = BigInt(lookupCampaignId);
+			const data = (await readContract(AD_CAMPAIGNS_FUNCTIONS.campaigns, [id])) as [
+				string,
+				string,
+				string,
+				string,
+				bigint,
+				bigint,
+				bigint,
+				bigint,
+				boolean,
+				boolean
+			];
+			const remainingResult = (await readContract(AD_CAMPAIGNS_FUNCTIONS.remainingBudget, [
+				id
+			])) as [bigint];
+			campaign = {
+				advertiser: data[0],
+				adId: data[1],
+				linkId: data[2],
+				linkToken: data[3],
+				cpc: data[4],
+				deposited: data[5],
+				spent: data[6],
+				clicks: data[7],
+				paused: data[8],
+				closed: data[9],
+				remaining: remainingResult[0]
+			};
+			await refreshRevenue();
+		} catch (error) {
+			console.error(error);
+			manageStatus = error instanceof Error ? error.message : 'Failed to load campaign';
+			campaign = null;
+		}
+	}
+
+	async function refreshRevenue() {
+		if (!campaign) return;
+		const [revenue] = (await readContract(DISTRIBUTOR_FUNCTIONS.revenue24h, [
+			campaign.linkToken
+		])) as [bigint];
+		topLineRevenue = revenue;
+	}
+
+	async function fund(amount: string) {
+		if (!$account || !campaign) {
+			manageStatus = 'Connect your wallet and load a campaign.';
+			return;
+		}
+		const parsed = parseUnits(amount, 6);
+		if (parsed === 0n) {
+			manageStatus = 'Enter a positive USDC amount.';
+			return;
+		}
+		isBusy = true;
+		try {
+			await writeContract($account, AD_CAMPAIGNS_FUNCTIONS.fundCampaign, [
+				BigInt(lookupCampaignId),
+				parsed
+			]);
+			manageStatus = 'Funding transaction sent. Approve USDC allowance first.';
+			await loadCampaign();
+		} catch (error) {
+			console.error(error);
+			manageStatus = error instanceof Error ? error.message : 'Failed to fund campaign';
+		} finally {
+			isBusy = false;
+		}
+	}
+
+	async function setPause(paused: boolean) {
+		if (!$account) {
+			manageStatus = 'Connect your wallet to update status.';
+			return;
+		}
+		isBusy = true;
+		try {
+			await writeContract($account, AD_CAMPAIGNS_FUNCTIONS.pauseCampaign, [
+				BigInt(lookupCampaignId),
+				paused
+			]);
+			manageStatus = paused ? 'Campaign paused.' : 'Campaign resumed.';
+			await loadCampaign();
+		} catch (error) {
+			console.error(error);
+			manageStatus = error instanceof Error ? error.message : 'Failed to update status';
+		} finally {
+			isBusy = false;
+		}
+	}
+
+	async function closeCampaign(refundAddress: string) {
+		if (!$account) {
+			manageStatus = 'Connect your wallet to close the campaign.';
+			return;
+		}
+		isBusy = true;
+		try {
+			await writeContract($account, AD_CAMPAIGNS_FUNCTIONS.closeCampaign, [
+				BigInt(lookupCampaignId),
+				refundAddress || $account
+			]);
+			manageStatus = 'Close transaction submitted.';
+			await loadCampaign();
+		} catch (error) {
+			console.error(error);
+			manageStatus = error instanceof Error ? error.message : 'Failed to close campaign';
+		} finally {
+			isBusy = false;
+		}
+	}
+
+	function triggerPause(nextPaused: boolean) {
+		if (!campaign) return;
+		setPause(nextPaused);
+	}
+
+	function triggerClose() {
+		if (!campaign) return;
+		closeCampaign(campaign.advertiser);
+	}
+</script>
+
+<div class="space-y-10">
+	<section class="rounded-2xl border border-zinc-800 bg-zinc-900/30 p-8">
+		<h2 class="text-xl font-semibold text-white">Create a new campaign</h2>
+		<p class="mt-2 text-sm text-zinc-400">
+			Fund USDC on Base, set a CPC and point to a canonical Farcaster link. Each validated click
+			will move the CPC amount into the link token reward pool.
+		</p>
+
+		<div class="mt-6 grid gap-4 md:grid-cols-2">
+			<label class="text-sm text-zinc-300">
+				Advertised link
+				<input
+					class="mt-2 w-full rounded border border-zinc-700 bg-zinc-950/80 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+					bind:value={rawLink}
+					on:blur={computeCanonical}
+					placeholder="https://warpcast.com/..."
+				/>
+			</label>
+			<label class="text-sm text-zinc-300">
+				Ad identifier (cast hash or label)
+				<input
+					class="mt-2 w-full rounded border border-zinc-700 bg-zinc-950/80 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+					bind:value={adIdInput}
+					placeholder="auto-hash if blank"
+				/>
+			</label>
+			<label class="text-sm text-zinc-300">
+				CPC (USDC)
+				<input
+					class="mt-2 w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+					bind:value={cpcInput}
+					placeholder="0.25"
+				/>
+			</label>
+			<label class="text-sm text-zinc-300">
+				Initial budget (USDC)
+				<input
+					class="mt-2 w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+					bind:value={budgetInput}
+					placeholder="100"
+				/>
+			</label>
+		</div>
+		<div class="mt-4 grid gap-2 text-xs text-zinc-400">
+			<span>Canonical: <span class="font-mono text-zinc-200">{canonicalLink || '—'}</span></span>
+			<span>Link ID: <span class="font-mono text-zinc-200">{linkId || '—'}</span></span>
+			<span
+				>Link token: <span class="font-mono text-zinc-200"
+					>{linkTokenAddress ?? 'Lookup pending'}</span
+				></span
+			>
+		</div>
+		<div class="mt-6 flex gap-3">
+			<button
+				class="rounded bg-zinc-800 px-4 py-2 text-sm hover:bg-zinc-700"
+				on:click={lookupLinkToken}
+				disabled={isBusy}
+			>
+				Lookup token
+			</button>
+			<button
+				class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-60"
+				on:click={handleCreateCampaign}
+				disabled={isBusy}
+			>
+				Create campaign
+			</button>
+		</div>
+		{#if createStatus}
+			<p class="mt-4 text-xs text-zinc-400">{createStatus}</p>
+		{/if}
+		{#if createdCampaignTx}
+			<p class="mt-2 text-sm text-emerald-300">Track your campaign tx: {createdCampaignTx}</p>
+		{/if}
+	</section>
+
+	<section class="rounded-2xl border border-zinc-800 bg-zinc-900/30 p-8">
+		<h2 class="text-xl font-semibold text-white">Manage campaign</h2>
+		<div class="mt-4 flex flex-wrap items-end gap-3">
+			<label class="text-sm text-zinc-300">
+				Campaign ID
+				<input
+					class="mt-2 w-40 rounded border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+					bind:value={lookupCampaignId}
+				/>
+			</label>
+			<button
+				class="rounded bg-zinc-800 px-4 py-2 text-sm hover:bg-zinc-700"
+				on:click={loadCampaign}
+				disabled={!lookupCampaignId || isBusy}
+			>
+				Load
+			</button>
+		</div>
+
+		{#if campaign}
+			<div class="mt-6 grid gap-4 lg:grid-cols-2">
+				<div class="rounded-xl border border-zinc-800 bg-zinc-950/40 p-6">
+					<h3 class="text-sm font-semibold text-zinc-200">Campaign details</h3>
+					<dl class="mt-4 space-y-2 text-sm text-zinc-300">
+						<div class="flex justify-between">
+							<dt>Advertiser</dt>
+							<dd class="font-mono">{campaign.advertiser}</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt>Link token</dt>
+							<dd class="font-mono">{campaign.linkToken}</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt>CPC</dt>
+							<dd>{formatUSD(campaign.cpc)}</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt>Budget</dt>
+							<dd>{formatUSD(campaign.deposited)}</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt>Spent</dt>
+							<dd>{formatUSD(campaign.spent)}</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt>Remaining</dt>
+							<dd>{formatUSD(campaign.remaining)}</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt>Total clicks</dt>
+							<dd>{campaign.clicks.toString()}</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt>Status</dt>
+							<dd>{campaign.closed ? 'Closed' : campaign.paused ? 'Paused' : 'Active'}</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt>24h link revenue</dt>
+							<dd>{formatUSD(topLineRevenue)}</dd>
+						</div>
+					</dl>
+				</div>
+				<div class="space-y-4 rounded-xl border border-zinc-800 bg-zinc-950/40 p-6">
+					<h3 class="text-sm font-semibold text-zinc-200">Actions</h3>
+					<label class="text-sm text-zinc-300">
+						Add budget (USDC)
+						<div class="mt-2 flex gap-2">
+							<input
+								class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+								bind:value={fundInput}
+								placeholder="25"
+							/>
+							<button
+								class="rounded bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+								on:click={() => fund(fundInput)}
+								disabled={isBusy}>Fund</button
+							>
+						</div>
+					</label>
+					<div class="flex flex-wrap gap-2">
+						<button
+							class="rounded bg-yellow-600/80 px-4 py-2 text-sm text-white hover:bg-yellow-500"
+							on:click={() => triggerPause(true)}
+							disabled={campaign.paused || isBusy}>Pause</button
+						>
+						<button
+							class="rounded bg-sky-600 px-4 py-2 text-sm text-white hover:bg-sky-500"
+							on:click={() => triggerPause(false)}
+							disabled={!campaign.paused || isBusy}>Resume</button
+						>
+						<button
+							class="rounded bg-rose-600 px-4 py-2 text-sm text-white hover:bg-rose-500"
+							on:click={triggerClose}
+							disabled={campaign.closed || isBusy}>Close & Refund</button
+						>
+					</div>
+				</div>
+			</div>
+		{:else if manageStatus}
+			<p class="mt-4 text-sm text-zinc-400">{manageStatus}</p>
+		{/if}
+		{#if manageStatus && campaign}
+			<p class="mt-4 text-xs text-zinc-400">{manageStatus}</p>
+		{/if}
+	</section>
+</div>

--- a/src/routes/buy/+page.svelte
+++ b/src/routes/buy/+page.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { account } from '$lib/blockchain/wallet';
+	import { linkIdFromRawLink } from '$lib/utils/canonicalize-link';
+	import {
+		FACTORY_FUNCTIONS,
+		DISTRIBUTOR_FUNCTIONS,
+		readContract,
+		writeContract,
+		linkTokenFunction,
+		CONTRACTS
+	} from '$lib/blockchain/contracts';
+	import { formatPercent, formatUnits, formatUSD, parseUnits } from '$lib/utils/format';
+
+	let rawLink = '';
+	let canonicalLink = '';
+	let linkId = '';
+	let linkTokenAddress: string | null = null;
+	let tokenPrice = 0n;
+	let totalSupply = 0n;
+	let revenue24h = 0n;
+	let userPending = 0n;
+	let userBalance = 0n;
+	let isBusy = false;
+	let statusMessage = '';
+	let amountInput = '';
+	let txHash: string | null = null;
+	let autoCanon = false;
+
+	function computeCanonical() {
+		if (!rawLink) {
+			canonicalLink = '';
+			linkId = '';
+			return;
+		}
+		const { canonical, linkId: computedId } = linkIdFromRawLink(rawLink);
+		canonicalLink = canonical;
+		linkId = computedId;
+	}
+
+	$: (autoCanon, rawLink, autoCanon && computeCanonical());
+
+	async function fetchTokenPrice() {
+		const [price] = (await readContract(FACTORY_FUNCTIONS.tokenPrice, [])) as [bigint];
+		tokenPrice = price;
+	}
+
+	async function resolveTokenAddress() {
+		if (!linkId) {
+			computeCanonical();
+		}
+		if (!linkId) return;
+		if (!CONTRACTS.address || CONTRACTS.address === '0x0000000000000000000000000000000000000000') {
+			statusMessage = 'Factory address not configured (VITE_FACTORY_ADDRESS).';
+			return;
+		}
+		const [address] = (await readContract(FACTORY_FUNCTIONS.getLinkToken, [linkId])) as [string];
+		linkTokenAddress = address !== '0x0000000000000000000000000000000000000000' ? address : null;
+		if (linkTokenAddress) {
+			await refreshTokenStats();
+		}
+	}
+
+	async function refreshTokenStats() {
+		if (!linkTokenAddress) return;
+		const supplyResult = (await readContract(
+			linkTokenFunction(linkTokenAddress, 'totalSupply'),
+			[]
+		)) as [bigint];
+		totalSupply = supplyResult[0];
+		if ($account) {
+			const balanceResult = (await readContract(linkTokenFunction(linkTokenAddress, 'balanceOf'), [
+				$account
+			])) as [bigint];
+			userBalance = balanceResult[0];
+			const [pending] = (await readContract(DISTRIBUTOR_FUNCTIONS.pendingRewards, [
+				linkTokenAddress,
+				$account
+			])) as [bigint];
+			userPending = pending;
+		} else {
+			userBalance = 0n;
+			userPending = 0n;
+		}
+		const [last24h] = (await readContract(DISTRIBUTOR_FUNCTIONS.revenue24h, [
+			linkTokenAddress
+		])) as [bigint];
+		revenue24h = last24h;
+	}
+
+	async function handleCreateToken() {
+		if (!linkId || !canonicalLink) {
+			computeCanonical();
+		}
+		if (!linkId || !canonicalLink) {
+			statusMessage = 'Provide a link to continue.';
+			return;
+		}
+		if (!CONTRACTS.address || CONTRACTS.address === '0x0000000000000000000000000000000000000000') {
+			statusMessage =
+				'Factory address is not configured. Set VITE_FACTORY_ADDRESS in your environment.';
+			return;
+		}
+		if (!$account) {
+			statusMessage = 'Connect your wallet to create a link token.';
+			return;
+		}
+		isBusy = true;
+		statusMessage = 'Submitting transaction…';
+		try {
+			const tx = await writeContract($account, FACTORY_FUNCTIONS.getOrCreateLinkToken, [
+				linkId,
+				canonicalLink,
+				'LINK'
+			]);
+			txHash = tx;
+			statusMessage = 'Token creation submitted. Once mined, refresh to load stats.';
+			await resolveTokenAddress();
+		} catch (error) {
+			console.error(error);
+			statusMessage = error instanceof Error ? error.message : 'Failed to create token';
+		} finally {
+			isBusy = false;
+		}
+	}
+
+	async function handlePurchase() {
+		if (!linkTokenAddress) {
+			statusMessage = 'Resolve or create a link token first.';
+			return;
+		}
+		if (!$account) {
+			statusMessage = 'Connect your wallet to buy tokens.';
+			return;
+		}
+		if (!amountInput) {
+			statusMessage = 'Enter an amount of tokens to buy.';
+			return;
+		}
+		try {
+			const parsed = parseUnits(amountInput, 18);
+			isBusy = true;
+			statusMessage = 'Submitting purchase…';
+			const tx = await writeContract($account, FACTORY_FUNCTIONS.purchase, [
+				linkId,
+				parsed,
+				$account
+			]);
+			txHash = tx;
+			statusMessage = 'Purchase sent. Approve USDC beforehand to avoid failures.';
+			await refreshTokenStats();
+		} catch (error) {
+			console.error(error);
+			statusMessage = error instanceof Error ? error.message : 'Failed to buy tokens';
+		} finally {
+			isBusy = false;
+		}
+	}
+
+	$: if ($account && linkTokenAddress) {
+		refreshTokenStats();
+	}
+
+	onMount(async () => {
+		await fetchTokenPrice();
+		computeCanonical();
+	});
+</script>
+
+<div class="grid gap-8 lg:grid-cols-[1.2fr,1fr]">
+	<section class="rounded-2xl border border-zinc-800 bg-zinc-900/30 p-8">
+		<h2 class="text-xl font-semibold text-white">Buy link tokens</h2>
+		<p class="mt-2 text-sm text-zinc-400">
+			Paste a Farcaster cast URL or any link. We canonicalize it and look up its link token. If it
+			does not exist yet you can create it with a single transaction.
+		</p>
+
+		<div class="mt-6 space-y-4">
+			<label class="block text-sm font-medium text-zinc-300">
+				Raw link
+				<input
+					class="mt-2 w-full rounded border border-zinc-700 bg-zinc-950/80 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+					bind:value={rawLink}
+					placeholder="https://warpcast.com/..."
+				/>
+			</label>
+			<label class="flex items-center gap-2 text-xs text-zinc-400">
+				<input type="checkbox" bind:checked={autoCanon} /> auto-canonicalize
+			</label>
+			<div class="grid gap-3 text-sm text-zinc-300">
+				<div>
+					<span class="font-medium text-zinc-400">Canonical link:</span>
+					<span class="ml-2 font-mono text-zinc-200">{canonicalLink || '—'}</span>
+				</div>
+				<div>
+					<span class="font-medium text-zinc-400">Link ID:</span>
+					<span class="ml-2 font-mono text-zinc-200">{linkId || '—'}</span>
+				</div>
+				<div>
+					<span class="font-medium text-zinc-400">Token address:</span>
+					<span class="ml-2 font-mono text-zinc-200">{linkTokenAddress ?? 'Not deployed'}</span>
+				</div>
+			</div>
+			<div class="flex flex-wrap gap-3">
+				<button
+					class="rounded bg-zinc-800 px-4 py-2 text-sm hover:bg-zinc-700"
+					on:click={resolveTokenAddress}
+					disabled={!linkId || isBusy}
+				>
+					Lookup token
+				</button>
+				<button
+					class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-60"
+					on:click={handleCreateToken}
+					disabled={!linkId || isBusy}
+				>
+					Create link token
+				</button>
+			</div>
+		</div>
+
+		<div class="mt-8 rounded-xl border border-zinc-800 bg-zinc-950/60 p-6">
+			<h3 class="text-sm font-semibold text-zinc-200">Purchase</h3>
+			<p class="mt-1 text-xs text-zinc-500">
+				Price per token: {formatUSD(tokenPrice)} (assuming 18 decimal token supply).
+			</p>
+			<div class="mt-4 grid gap-4">
+				<label class="text-sm text-zinc-300">
+					Amount of tokens
+					<input
+						class="mt-2 w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+						bind:value={amountInput}
+						placeholder="10"
+					/>
+				</label>
+				<button
+					class="rounded bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-60"
+					on:click={handlePurchase}
+					disabled={!amountInput || isBusy}
+				>
+					Buy tokens
+				</button>
+				{#if txHash}
+					<p class="text-xs text-emerald-300">
+						Submitted: <span class="font-mono">{txHash}</span>
+					</p>
+				{/if}
+			</div>
+			{#if statusMessage}
+				<p class="mt-4 text-xs text-zinc-400">{statusMessage}</p>
+			{/if}
+		</div>
+	</section>
+
+	<aside class="space-y-4">
+		<div class="rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6">
+			<h3 class="text-sm font-semibold text-zinc-200">Token metrics</h3>
+			<dl class="mt-4 space-y-2 text-sm text-zinc-300">
+				<div class="flex justify-between">
+					<dt>Total supply</dt>
+					<dd class="font-mono">{formatUnits(totalSupply, 18)}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt>24h click revenue</dt>
+					<dd class="font-mono">{formatUSD(revenue24h)}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt>Your balance</dt>
+					<dd class="font-mono">{formatUnits(userBalance, 18)}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt>Your share of last 24h</dt>
+					<dd class="font-mono">
+						{formatUSD(totalSupply > 0n ? (revenue24h * userBalance) / totalSupply : 0n)}
+					</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt>Unclaimed rewards</dt>
+					<dd class="font-mono">{formatUSD(userPending)}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt>Ownership</dt>
+					<dd class="font-mono">{formatPercent(userBalance, totalSupply)}</dd>
+				</div>
+			</dl>
+		</div>
+	</aside>
+</div>

--- a/src/routes/claim/+page.svelte
+++ b/src/routes/claim/+page.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+	import { account } from '$lib/blockchain/wallet';
+	import { onMount } from 'svelte';
+	import {
+		FACTORY_FUNCTIONS,
+		DISTRIBUTOR_FUNCTIONS,
+		readContract,
+		writeContract,
+		linkTokenFunction,
+		CONTRACTS
+	} from '$lib/blockchain/contracts';
+	import { formatUSD, formatUnits } from '$lib/utils/format';
+
+	interface Holding {
+		address: string;
+		balance: bigint;
+		pending: bigint;
+		revenue24h: bigint;
+	}
+
+	let holdings: Holding[] = [];
+	let isLoading = false;
+	let claimStatus = '';
+
+	async function loadHoldings() {
+		if (!$account) {
+			holdings = [];
+			return;
+		}
+		if (!CONTRACTS.address || CONTRACTS.address === '0x0000000000000000000000000000000000000000') {
+			claimStatus = 'Factory address missing (set VITE_FACTORY_ADDRESS).';
+			holdings = [];
+			return;
+		}
+		isLoading = true;
+		claimStatus = '';
+		try {
+			const [tokenList] = (await readContract(FACTORY_FUNCTIONS.getAllLinkTokens, [])) as [
+				string[]
+			];
+			const results: Holding[] = [];
+			for (const token of tokenList) {
+				const [balance] = (await readContract(linkTokenFunction(token, 'balanceOf'), [
+					$account
+				])) as [bigint];
+				const [pending] = (await readContract(DISTRIBUTOR_FUNCTIONS.pendingRewards, [
+					token,
+					$account
+				])) as [bigint];
+				if (balance > 0n || pending > 0n) {
+					const [revenue] = (await readContract(DISTRIBUTOR_FUNCTIONS.revenue24h, [token])) as [
+						bigint
+					];
+					results.push({ address: token, balance, pending, revenue24h: revenue });
+				}
+			}
+			holdings = results;
+		} catch (error) {
+			console.error(error);
+			claimStatus = error instanceof Error ? error.message : 'Failed to load holdings';
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function claim(token: string) {
+		if (!$account) {
+			claimStatus = 'Connect wallet to claim.';
+			return;
+		}
+		isLoading = true;
+		try {
+			const tx = await writeContract($account, DISTRIBUTOR_FUNCTIONS.claim, [token, $account]);
+			claimStatus = `Claim submitted: ${tx}`;
+			await loadHoldings();
+		} catch (error) {
+			console.error(error);
+			claimStatus = error instanceof Error ? error.message : 'Failed to claim rewards';
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function claimAll() {
+		if (!$account) {
+			claimStatus = 'Connect wallet to claim.';
+			return;
+		}
+		if (holdings.length === 0) {
+			claimStatus = 'Nothing to claim.';
+			return;
+		}
+		isLoading = true;
+		try {
+			const tx = await writeContract($account, DISTRIBUTOR_FUNCTIONS.claimBatch, [
+				holdings.map((h) => h.address),
+				$account
+			]);
+			claimStatus = `Batch claim submitted: ${tx}`;
+			await loadHoldings();
+		} catch (error) {
+			console.error(error);
+			claimStatus = error instanceof Error ? error.message : 'Failed to claim rewards';
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	$: ($account, loadHoldings());
+
+	onMount(() => {
+		loadHoldings();
+	});
+</script>
+
+<section class="rounded-2xl border border-zinc-800 bg-zinc-900/30 p-8">
+	<div class="flex items-center justify-between">
+		<div>
+			<h2 class="text-xl font-semibold text-white">Claim rewards</h2>
+			<p class="text-sm text-zinc-400">
+				View every link token you hold and pull down accrued USDC.
+			</p>
+		</div>
+		<button
+			class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-60"
+			on:click={loadHoldings}
+			disabled={isLoading}
+		>
+			Refresh
+		</button>
+	</div>
+
+	{#if !$account}
+		<p class="mt-6 text-sm text-zinc-400">Connect your wallet to see claimable balances.</p>
+	{:else}
+		<div class="mt-6 flex justify-between text-sm text-zinc-300">
+			<span>Total tokens tracked: {holdings.length}</span>
+			<button
+				class="rounded bg-emerald-600 px-3 py-1 text-sm text-white hover:bg-emerald-500 disabled:opacity-60"
+				on:click={claimAll}
+				disabled={isLoading || holdings.length === 0}
+			>
+				Claim all
+			</button>
+		</div>
+		<div class="mt-4 space-y-4">
+			{#if holdings.length === 0}
+				<p
+					class="rounded border border-dashed border-zinc-700 bg-zinc-950/60 p-6 text-sm text-zinc-400"
+				>
+					No balances detected. Acquire link tokens or wait for clicks to accrue rewards.
+				</p>
+			{:else}
+				{#each holdings as holding}
+					<div class="rounded-xl border border-zinc-800 bg-zinc-950/50 p-5">
+						<div class="flex flex-wrap items-center justify-between gap-4">
+							<div>
+								<p class="font-mono text-sm text-zinc-200">{holding.address}</p>
+								<p class="text-xs text-zinc-500">
+									24h link revenue: {formatUSD(holding.revenue24h)}
+								</p>
+							</div>
+							<div class="grid grid-cols-2 gap-6 text-sm text-zinc-300">
+								<div>
+									<p class="text-xs text-zinc-500 uppercase">Balance</p>
+									<p class="font-mono text-base text-white">{formatUnits(holding.balance, 18)}</p>
+								</div>
+								<div>
+									<p class="text-xs text-zinc-500 uppercase">Claimable USDC</p>
+									<p class="font-mono text-base text-emerald-300">{formatUSD(holding.pending)}</p>
+								</div>
+							</div>
+							<button
+								class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+								on:click={() => claim(holding.address)}
+								disabled={holding.pending === 0n || isLoading}
+							>
+								Claim
+							</button>
+						</div>
+					</div>
+				{/each}
+			{/if}
+		</div>
+	{/if}
+
+	{#if claimStatus}
+		<p class="mt-6 text-xs text-zinc-400">{claimStatus}</p>
+	{/if}
+</section>


### PR DESCRIPTION
## Summary
- add Solidity contracts for link token issuance, rewards distribution, and attested CPC campaign settlement on Base
- build SvelteKit pages for buying link tokens, funding/controlling campaigns, and claiming USDC rewards with wallet connectivity
- create shared TypeScript utilities for keccak canonicalization, ABI encoding, RPC helpers, and wallet state management

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e2c9b2157083339a5f578cf855ea67