### PR TITLE
Improve wallet connect error handling

### DIFF
--- a/src/lib/components/ConnectWallet.svelte
+++ b/src/lib/components/ConnectWallet.svelte
@@ -1,27 +1,67 @@
 <script lang="ts">
-	import { account, connectWallet, disconnectWallet } from '$lib/blockchain/wallet';
+	import { browser } from '$app/environment';
 	import { onMount } from 'svelte';
-	import { initializeWallet } from '$lib/blockchain/wallet';
+	import {
+		account,
+		connectWallet,
+		disconnectWallet,
+		initializeWallet
+	} from '$lib/blockchain/wallet';
 
 	let isConnecting = false;
+	let hasWallet = false;
+	let errorMessage = '';
+
+	function updateWalletPresence(): boolean {
+		if (!browser) return false;
+		const { ethereum } = window as typeof window & { ethereum?: unknown };
+		hasWallet = Boolean(ethereum);
+		if (hasWallet) {
+			errorMessage = '';
+		}
+		return hasWallet;
+	}
 
 	onMount(() => {
+		if (browser) {
+			updateWalletPresence();
+			window.addEventListener(
+				'ethereum#initialized',
+				() => {
+					updateWalletPresence();
+				},
+				{ once: true }
+			);
+		}
 		initializeWallet();
 	});
 
 	async function handleConnect() {
 		if (isConnecting) return;
+		errorMessage = '';
+		if (!updateWalletPresence()) {
+			errorMessage =
+				'No browser wallet detected. Install MetaMask or another Base-compatible wallet.';
+			return;
+		}
 		isConnecting = true;
 		try {
 			await connectWallet();
 		} catch (error) {
 			console.error('Failed to connect wallet', error);
+			const walletError = error as Error & { code?: number };
+			if (walletError?.code === 4001) {
+				errorMessage = 'Connection request rejected.';
+			} else {
+				errorMessage = walletError?.message ?? 'Failed to connect wallet';
+			}
 		} finally {
 			isConnecting = false;
 		}
 	}
 
 	function handleDisconnect() {
+		errorMessage = '';
 		disconnectWallet();
 	}
 </script>
@@ -39,11 +79,16 @@
 		</button>
 	</div>
 {:else}
-	<button
-		class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-60"
-		on:click={handleConnect}
-		disabled={isConnecting}
-	>
-		{isConnecting ? 'Connecting…' : 'Connect Wallet'}
-	</button>
+	<div class="flex flex-col items-stretch gap-1">
+		<button
+			class="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-60"
+			on:click={handleConnect}
+			disabled={isConnecting}
+		>
+			{isConnecting ? 'Connecting…' : 'Connect Wallet'}
+		</button>
+		{#if errorMessage}
+			<p class="text-xs text-rose-400 sm:text-right">{errorMessage}</p>
+		{/if}
+	</div>
 {/if}


### PR DESCRIPTION
## Summary
- detect whether a browser wallet is present before attempting to connect
- surface user-friendly messaging when no provider is available or a request is rejected
- keep the connect wallet button layout consistent while showing inline feedback

## Testing
- `npm run check`
- `npm test` *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cfe39f7c8333aee507f5438f005d